### PR TITLE
Hf1

### DIFF
--- a/src/chain.js
+++ b/src/chain.js
@@ -630,7 +630,7 @@ let chain = {
         let witnessRewardReceipients = {}
         let firstIndex = Math.max(0,chain.recentBlocks.length - config.witnessRewardBlocks + 1) // last n producers + current producer
         if (config.ecoVersion === 1)
-            reward *= votes
+            reward *= voteCount
         for (let i = firstIndex; i < chain.recentBlocks.length; i++) 
             if (!witnessRewardReceipients[chain.recentBlocks[i].miner])
                 witnessRewardReceipients[chain.recentBlocks[i].miner] = reward

--- a/src/chain.js
+++ b/src/chain.js
@@ -516,7 +516,7 @@ let chain = {
         // revalidating transactions in orders if revalidate = true
         // adding transaction to recent transactions (to prevent tx re-use) if isFinal = true
         var executions = []
-        let votes = 0 // for witness reward calculation
+        let voteCount = 0 // for witness reward calculation
         let executedSuccessfully = []
         for (let i = 0; i < block.txs.length; i++) 
             executions.push(function(callback) {
@@ -530,7 +530,7 @@ let chain = {
                                     process.exit(1)
                                 }
                                 if (tx.type === txtypes.VOTE)
-                                    votes++
+                                    voteCount++
                                 if (isFinal)
                                     chain.recentTxs[tx.hash] = tx
                                 if (executed)
@@ -547,7 +547,7 @@ let chain = {
                         if (!executed)
                             logr.fatal('Tx execution failure', tx)
                         if (tx.type === txtypes.VOTE)
-                            votes++
+                            voteCount++
                         if (isFinal)
                             chain.recentTxs[tx.hash] = tx
                         if (executed)
@@ -564,8 +564,8 @@ let chain = {
             logr.debug('Block '+string+' in '+(new Date().getTime()-blockTimeBefore)+'ms')
             if (err) throw err
 
-            // add rewards for the witness who mined this block
-            chain.witnessRewards(block.miner, block.timestamp, votes, () => cb(executedSuccessfully))
+            // process curations and witness rewards
+            eco.curationv2(block.timestamp,() => chain.witnessRewards(block.miner, block.timestamp, voteCount, () => cb(executedSuccessfully)))
         })
     },
     minerSchedule: (block) => {
@@ -621,14 +621,16 @@ let chain = {
         })
         return witnesses.slice(start, limit)
     },
-    witnessRewards: (name, ts, votes, cb) => {
-        // rewards witnesses who produced in the last config.witnessReward blocks with 0.01 Token/producer
-        if (votes <= 0)
+    witnessRewards: (name, ts, voteCount, cb) => {
+        // rewards witnesses who produced in the last config.witnessRewardBlocks with config.witnessReward Token/producer
+        if (voteCount <= 0)
             return cb(0)
-        let reward = config.witnessReward * votes
+        let reward = config.witnessReward
         let witnessRewardOp = []
         let witnessRewardReceipients = {}
-        let firstIndex = Math.max(0,chain.recentBlocks.length - config.witnessRewardBlocks + 1) // last 10 producers + current producer
+        let firstIndex = Math.max(0,chain.recentBlocks.length - config.witnessRewardBlocks + 1) // last n producers + current producer
+        if (config.ecoVersion === 1)
+            reward *= votes
         for (let i = firstIndex; i < chain.recentBlocks.length; i++) 
             if (!witnessRewardReceipients[chain.recentBlocks[i].miner])
                 witnessRewardReceipients[chain.recentBlocks[i].miner] = reward

--- a/src/config.js
+++ b/src/config.js
@@ -48,6 +48,8 @@ var config = {
             ecoCurationVtBase: 50,
             // incremental vp multiplier for following votes within a 24 hour window
             ecoCurationVtMult: 1.33,
+            // economy revision
+            ecoVersion: 1,
             // the maximum number of follows a single account can do
             followsMax: 2000,
             // the max size of a stringified json input (content / user profile)
@@ -143,6 +145,46 @@ var config = {
             vpGrowth: 120000000000, // +1 VP per 2 minutes per Token (60 * 1000 * 1000000 * 2min)
             // hard cap on maximum VP an account can have
             vpMax: 16000
+        },
+        5000000: {
+            // fixed emissions at 0.3 Token/block
+            ecoVersion: 2,
+            ecoAuthorReward: 36000,
+            ecoCurationReward: 24000,
+            vaults: {
+                airdrop: {
+                    // airdrop rewards for authors with no ref defined
+                    name: 'breeze-airdrop',
+                    reward: 6000 // 0.006 Token
+                },
+                lpMining: {
+                    // LP mining rewards
+                    name: 'breeze-lpminer',
+                    reward: 90000 // 0.09 Token
+                },
+                staking: {
+                    // staking rewards
+                    name: 'breeze-staker',
+                    reward: 60000 // 0.06 Token
+                },
+                daf: {
+                    // development appraisal fund
+                    name: 'breeze-daf',
+                    reward: 6000 // 0.006 Token
+                },
+                dao: {
+                    // dao fund
+                    name: 'breeze-dao',
+                    reward: 30000 // 0.03 Token
+                },
+                charity: {
+                    // charity share
+                    name: 'breeze-charity',
+                    reward: 3000 // 0.003 Token
+                }
+            },
+            witnessReward: 3000,
+            witnessRewardBlocks: 15, // 0.045 Token over last 15 witnesses, 0.003 each
         }
     },
     read: (blockNum) => {

--- a/src/config.js
+++ b/src/config.js
@@ -148,6 +148,7 @@ var config = {
         },
         5000000: {
             // fixed emissions at 0.3 Token/block
+            accountMinLengthFeelessMaster: 1,
             ecoVersion: 2,
             ecoAuthorReward: 36000,
             ecoCurationReward: 24000,

--- a/src/economics.js
+++ b/src/economics.js
@@ -49,7 +49,7 @@ var eco = {
         let dists = {}
         let ops = []
         for (let au in eco.currentBlock.votes)
-            for (let li in eco.currentBlock.votes[a]) {
+            for (let li in eco.currentBlock.votes[au]) {
                 let a = au
                 let l = li
                 // author reward for post
@@ -97,6 +97,16 @@ var eco = {
             }
         for (let d in dists)
             ops.push(eco.incBalanceOp2(d,dists[d],ts))
+        for (let v in config.vaults)
+            if (config.vaults[v].reward > 0 && v !== 'airdrop') {
+                ops.push(eco.incBalanceOp2(config.vaults[v].name,config.vaults[v].reward,ts))
+                ops.push((callback) => cache.insertOne('distributed', {
+                    name: config.vaults[v].name,
+                    dist: config.vaults[v].reward,
+                    ts: ts,
+                    _id: ts+'/'+v
+                },() => callback()))
+            }
         if (ops.length > 0)
             series(ops,() => {
                 eco.complete()
@@ -160,7 +170,7 @@ var eco = {
         return (callback) => {
             cache.findOne('accounts', {name: author}, (err,authorAcc) => {
                 let refReceipient = authorAcc.ref ? authorAcc.ref : config.vaults.airdrop.name
-                let amt = Math.floor(ad*config.ecoAuthorReward/config.vaults.airdrop.reward)
+                let amt = Math.floor(ad*config.vaults.airdrop.reward/config.ecoAuthorReward)
                 cache.insertOne('distributed', {
                     name: refReceipient,
                     dist: amt,

--- a/src/economics.js
+++ b/src/economics.js
@@ -1,6 +1,18 @@
 const series = require('run-series')
 
 var eco = {
+    currentBlock: {
+        votes: {},
+        voteCount: 0,
+        vpCount: 0
+    },
+    complete: () => {
+        eco.currentBlock = {
+            votes: {},
+            voteCount: 0,
+            vpCount: 0
+        }
+    },
     accountPrice: (username) => {
         var price = config.accountPriceMin
         var extra = config.accountPriceBase - config.accountPriceMin
@@ -30,6 +42,71 @@ var eco = {
                 cb()
         })
     },
+    curationv2: (ts,cb) => {
+        // to be called once after executing all transactions in a block
+        if (config.ecoVersion !== 2 || eco.currentBlock.voteCount === 0)
+            return cb()
+        let dists = {}
+        let ops = []
+        for (let au in eco.currentBlock.votes)
+            for (let li in eco.currentBlock.votes[a]) {
+                let a = au
+                let l = li
+                // author reward for post
+                let ad = Math.floor(config.ecoAuthorReward*eco.currentBlock.votes[a][l].length/eco.currentBlock.voteCount)
+                let cdt = 0
+                ops.push((callback) => cache.insertOne('distributed', {
+                    name: a,
+                    dist: ad,
+                    ts: ts,
+                    _id: a+'/'+l+'/'+ts+'/author'
+                },() => callback()))
+                if (!dists[a])
+                    dists[a] = ad
+                else
+                    dists[a] += ad
+
+                // curation reward for post
+                for (let v in eco.currentBlock.votes[a][l]) {
+                    let cd = Math.floor(config.ecoCurationReward*eco.currentBlock.votes[a][l][v].vp/eco.currentBlock.vpCount)
+                    ops.push((callback) => cache.insertOne('distributed', {
+                        name: eco.currentBlock.votes[a][l][v].u,
+                        dist: cd,
+                        ts: ts,
+                        _id: a+'/'+l+'/'+eco.currentBlock.votes[a][l][v].u+'/curation'
+                    },() => callback()))
+                    if (!dists[eco.currentBlock.votes[a][l][v].u])
+                        dists[eco.currentBlock.votes[a][l][v].u] = cd
+                    else
+                        dists[eco.currentBlock.votes[a][l][v].u] += cd
+                    cdt += cd
+                }
+
+                // referral reward
+                ops.push(eco.referralReward2(a,l,ad,ts))
+
+                // update post info
+                ops.push((callback) => cache.findOne('contents',{_id:a+'/'+l},(e,c) => {
+                    for (let v in eco.currentBlock.votes[a][l])
+                        c.votes.push(eco.currentBlock.votes[a][l][v])
+                    cache.updateOne('contents',{_id:a+'/'+l},{
+                        $set: { votes: c.votes },
+                        $inc: { dist: ad + cdt, likes: eco.currentBlock.votes[a][l].length }
+                    },() => callback())
+                }))
+            }
+        for (let d in dists)
+            ops.push(eco.incBalanceOp2(d,dists[d],ts))
+        if (ops.length > 0)
+            series(ops,() => {
+                eco.complete()
+                cb()
+            })
+        else {
+            eco.complete()
+            cb()
+        }
+    },
     incBalanceOp: (author,link,vote,username,amount,label) => {
         return (callback) => {
             logr.trace('increment',username,amount)
@@ -52,6 +129,21 @@ var eco = {
             })
         }
     },
+    incBalanceOp2: (username,amount,ts) => {
+        return (callback) => {
+            logr.trace('increment2',username,amount)
+            cache.updateOne('accounts', {name: username}, {$inc: {balance: amount}}, () => {
+                cache.findOne('accounts', {name: username}, function(err, acc) {
+                    acc.balance -= amount
+                    transaction.updateGrowInts(acc, ts, function() {
+                        transaction.adjustNodeAppr(acc, amount, function() {
+                            callback()
+                        })
+                    })
+                })
+            })
+        }
+    },
     referralReward: (author,link,vote) => {
         // airdrop reward
         return (callback) => {
@@ -60,6 +152,21 @@ var eco = {
                     eco.incBalanceOp(author,link,vote,authorAcc.ref,config.vaults.airdrop.reward,'airdrop')(callback)
                 else
                     eco.incBalanceOp(author,link,vote,config.vaults.airdrop.name,config.vaults.airdrop.reward,'airdrop')(callback)
+            })
+        }
+    },
+    referralReward2: (author,link,ad,ts) => {
+        // referral reward v2
+        return (callback) => {
+            cache.findOne('accounts', {name: author}, (err,authorAcc) => {
+                let refReceipient = authorAcc.ref ? authorAcc.ref : config.vaults.airdrop.name
+                let amt = Math.floor(ad*config.ecoAuthorReward/config.vaults.airdrop.reward)
+                cache.insertOne('distributed', {
+                    name: refReceipient,
+                    dist: amt,
+                    ts: ts,
+                    _id: author+'/'+link+'/'+ts+'/referral'
+                },() => eco.incBalanceOp2(refReceipient,amt,ts)(callback))
             })
         }
     }

--- a/src/transactions/vote.js
+++ b/src/transactions/vote.js
@@ -35,6 +35,18 @@ module.exports = {
             ts: ts,
             vp: await transaction.nextVP(tx.sender,ts,-1)
         }
-        eco.curation(tx.data.author, tx.data.link, vote, () => cb(true))
+        if (config.ecoVersion === 1) {
+            eco.curation(tx.data.author, tx.data.link, vote, () => cb(true))
+        } else if (config.ecoVersion === 2) {
+            if (!eco.currentBlock.votes[tx.data.author])
+                eco.currentBlock.votes[tx.data.author] = {}
+            if (!eco.currentBlock.votes[tx.data.author][tx.data.link])
+                eco.currentBlock.votes[tx.data.author][tx.data.link] = [vote]
+            else
+                eco.currentBlock.votes[tx.data.author][tx.data.link].push(vote)
+            eco.currentBlock.voteCount++
+            eco.currentBlock.vpCount += vote.vp
+            cb(true)
+        }
     }
 }


### PR DESCRIPTION
This is 1st hardfork (HF1) on breeze main chain

# Main Changes

## Breeze Economy v2
With this hard fork breeze economy will change entirely from unlimited token generation to limited token generation. As compared to v1, where each upvote was generating 1 token and was divided into all contributors as per reward pool, v2 will produce 0.3 tokens in each block so a maximum of 8640 tokens will be produced in 24 hours time period.

## Reward Pool Change
With new economy implementation, reward pool structure is supposed to change as more reward for authors, curators and witnesses. As per new reward structure distribution will be like this

Authors 12% - Curators 8% - Affiliate/Airdrop 2% - Witnesses 15% - LP mining 30% - Staking 20% - Foundation 10% - DAF 2% - Charity 1%

## Feeless Account creation from Breeze Account
To enhance new user signup on dapps, feeless account creation for breeze main account is added.

## Blocks BSON indexer and appender
To optimize MongoDB memory usage and improve indexing efficiency, the blockchain data has been taken out of the database and would instead read and append to/from the blocks.bson file. 

## Transaction history indexing
Due to the changes required to take the blockchain data off the mongo database, a new env var TX_HISTORY has been introduced to allow indexing of transaction history separately, which is also more efficient than previous versions.

In addition, TX_HISTORY_ACCOUNTS may be specified to only index a comma-separated list of relevant accounts.

For example:

``export TX_HISTORY=1
export TX_HISTORY_ACCOUNTS=accountA,accountB``

## /history API
Due to the above changes, the /history API will now return an array of transactions in the same format as /tx, instead of an array of blocks containing the relevant transactions.